### PR TITLE
Fix NPE-ception in MvpDelegateImpl constructors

### DIFF
--- a/mvp/src/main/java/com/hannesdorfmann/mosby/mvp/delegate/ActivityMvpDelegateImpl.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby/mvp/delegate/ActivityMvpDelegateImpl.java
@@ -37,7 +37,7 @@ public class ActivityMvpDelegateImpl<V extends MvpView, P extends MvpPresenter<V
 
   public ActivityMvpDelegateImpl(MvpDelegateCallback<V, P> delegateCallback) {
     if (delegateCallback == null){
-      throw new NullPointerException(delegateCallback.getClass().getSimpleName()+" is null!");
+      throw new NullPointerException("MvpDelegateCallback is null!");
     }
     this.delegateCallback = delegateCallback;
   }
@@ -47,7 +47,7 @@ public class ActivityMvpDelegateImpl<V extends MvpView, P extends MvpPresenter<V
    */
   protected MvpInternalDelegate<V, P> getInternalDelegate() {
     if (internalDelegate == null) {
-      internalDelegate = new MvpInternalDelegate(delegateCallback);
+      internalDelegate = new MvpInternalDelegate<>(delegateCallback);
     }
 
     return internalDelegate;

--- a/mvp/src/main/java/com/hannesdorfmann/mosby/mvp/delegate/FragmentMvpDelegateImpl.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby/mvp/delegate/FragmentMvpDelegateImpl.java
@@ -40,7 +40,7 @@ public class FragmentMvpDelegateImpl<V extends MvpView, P extends MvpPresenter<V
 
   public FragmentMvpDelegateImpl(MvpDelegateCallback<V, P> delegateCallback) {
     if (delegateCallback == null) {
-      throw new NullPointerException(delegateCallback.getClass().getSimpleName() + " is null!");
+      throw new NullPointerException("MvpDelegateCallback is null!");
     }
 
     this.delegateCallback = delegateCallback;

--- a/mvp/src/main/java/com/hannesdorfmann/mosby/mvp/delegate/MvpInternalDelegate.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby/mvp/delegate/MvpInternalDelegate.java
@@ -34,7 +34,7 @@ class MvpInternalDelegate<V extends MvpView, P extends MvpPresenter<V>> {
   MvpInternalDelegate(MvpDelegateCallback<V, P> delegateCallback) {
 
     if (delegateCallback == null) {
-      throw new NullPointerException(delegateCallback.getClass().getSimpleName() + " is null!");
+      throw new NullPointerException("MvpDelegateCallback is null!");
     }
 
     this.delegateCallback = delegateCallback;

--- a/mvp/src/main/java/com/hannesdorfmann/mosby/mvp/delegate/ViewGroupMvpDelegateImpl.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby/mvp/delegate/ViewGroupMvpDelegateImpl.java
@@ -34,7 +34,7 @@ public class ViewGroupMvpDelegateImpl<V extends MvpView, P extends MvpPresenter<
 
   public ViewGroupMvpDelegateImpl(MvpDelegateCallback<V, P> delegateCallback) {
     if (delegateCallback == null) {
-      throw new NullPointerException(delegateCallback.getClass().getSimpleName() + " is null!");
+      throw new NullPointerException("MvpDelegateCallback is null!");
     }
     this.delegateCallback = delegateCallback;
   }


### PR DESCRIPTION
MvpDelegate implementations need a non-null MvpDelegateCallback upon creation, otherwise a NullPointerException is raised. However, accessing the callback reference in these cases will cause an NPE themselves! Because I wasn't ready to go deeper, I chose to correct this. In the end, it shouldn't really matter, as any app that reaches this point will crash to an NPE anyways, but it's something that caught my eye while reading through the changes of mosby 1.1.0.