### PR TITLE
Update buildToolsVersion to 23.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ allprojects {
 ext {
   minSdk = 14
   targetSdk = 23
-  buildToolsVersion = '23.0.0'
+  buildToolsVersion = '23.0.1'
   compileSdkVersion = 23
 
   javaSourceCompatibility = JavaVersion.VERSION_1_7


### PR DESCRIPTION
It seems, at least on OS X, the SDK manager does not even list 23.0.0 so that I could not import the project without fixing the buildToolsVersion first. See also the following link: https://github.com/Homebrew/homebrew/issues/43705