### PR TITLE
Add @UiThread annotation to presenter to make the contract explicit.

### DIFF
--- a/mvp-common/src/main/java/com/hannesdorfmann/mosby/mvp/MvpBasePresenter.java
+++ b/mvp-common/src/main/java/com/hannesdorfmann/mosby/mvp/MvpBasePresenter.java
@@ -17,6 +17,8 @@
 package com.hannesdorfmann.mosby.mvp;
 
 import android.support.annotation.Nullable;
+import android.support.annotation.UiThread;
+
 import java.lang.ref.WeakReference;
 
 /**
@@ -71,6 +73,7 @@ public class MvpBasePresenter<V extends MvpView> implements MvpPresenter<V> {
 
   private WeakReference<V> viewRef;
 
+  @UiThread
   @Override public void attachView(V view) {
     viewRef = new WeakReference<V>(view);
   }
@@ -82,6 +85,7 @@ public class MvpBasePresenter<V extends MvpView> implements MvpPresenter<V> {
    *
    * @return <code>null</code>, if view is not attached, otherwise the concrete view instance
    */
+  @UiThread
   @Nullable public V getView() {
     return viewRef == null ? null : viewRef.get();
   }
@@ -90,10 +94,12 @@ public class MvpBasePresenter<V extends MvpView> implements MvpPresenter<V> {
    * Checks if a view is attached to this presenter. You should always call this method before
    * calling {@link #getView()} to get the view instance.
    */
+  @UiThread
   public boolean isViewAttached() {
     return viewRef != null && viewRef.get() != null;
   }
 
+  @UiThread
   @Override public void detachView(boolean retainInstance) {
     if (viewRef != null) {
       viewRef.clear();

--- a/mvp-common/src/main/java/com/hannesdorfmann/mosby/mvp/MvpNullObjectBasePresenter.java
+++ b/mvp-common/src/main/java/com/hannesdorfmann/mosby/mvp/MvpNullObjectBasePresenter.java
@@ -1,6 +1,8 @@
 package com.hannesdorfmann.mosby.mvp;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.UiThread;
+
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
@@ -21,10 +23,12 @@ public class MvpNullObjectBasePresenter<V extends MvpView> implements MvpPresent
 
   private V view;
 
+  @UiThread
   @Override public void attachView(V view) {
     this.view = view;
   }
 
+  @UiThread
   @NonNull public V getView() {
     if (view == null) {
       throw new NullPointerException("MvpView reference is null. Have you called attachView()?");
@@ -32,6 +36,7 @@ public class MvpNullObjectBasePresenter<V extends MvpView> implements MvpPresent
     return view;
   }
 
+  @UiThread
   @Override public void detachView(boolean retainInstance) {
     if (view != null) {
 

--- a/mvp-common/src/main/java/com/hannesdorfmann/mosby/mvp/MvpPresenter.java
+++ b/mvp-common/src/main/java/com/hannesdorfmann/mosby/mvp/MvpPresenter.java
@@ -16,6 +16,8 @@
 
 package com.hannesdorfmann.mosby.mvp;
 
+import android.support.annotation.UiThread;
+
 /**
  * The base interface for each mvp presenter.
  *
@@ -32,11 +34,13 @@ public interface MvpPresenter<V extends MvpView> {
   /**
    * Set or attach the view to this presenter
    */
-  public void attachView(V view);
+  @UiThread
+  void attachView(V view);
 
   /**
    * Will be called if the view has been destroyed. Typically this method will be invoked from
    * <code>Activity.detachView()</code> or <code>Fragment.onDestroyView()</code>
    */
-  public void detachView(boolean retainInstance);
+  @UiThread
+  void detachView(boolean retainInstance);
 }

--- a/mvp-common/src/test/java/com/hannesdorfmann/mosby/mvp/MvpBasePresenterTest.java
+++ b/mvp-common/src/test/java/com/hannesdorfmann/mosby/mvp/MvpBasePresenterTest.java
@@ -3,6 +3,10 @@ package com.hannesdorfmann.mosby.mvp;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
 /**
  * @author Hannes Dorfmann
  */
@@ -34,5 +38,33 @@ public class MvpBasePresenterTest extends MvpBasePresenter<MvpView> {
 
   private void noViewAttached(){
     Assert.assertFalse(isViewAttached());
+  }
+
+  @Test
+  public void testAttachView() throws Exception {
+    MvpBasePresenter<MvpView> presenter = new MvpBasePresenter<>();
+    assertFalse(presenter.isViewAttached());
+    presenter.attachView(new MvpView() {
+    });
+    assertTrue(presenter.isViewAttached());
+  }
+
+  @Test
+  public void testGetView() throws Exception {
+    MvpBasePresenter<MvpView> presenter = new MvpBasePresenter<>();
+    MvpView mvpView = new MvpView() {
+    };
+    presenter.attachView(mvpView);
+    assertEquals(mvpView, presenter.getView());
+  }
+
+  @Test
+  public void testDetachView() throws Exception {
+    MvpBasePresenter<MvpView> presenter = new MvpBasePresenter<>();
+    MvpView mvpView = new MvpView() {
+    };
+    presenter.attachView(mvpView);
+    presenter.detachView(false);
+    assertEquals(null, presenter.getView());
   }
 }


### PR DESCRIPTION
If for example someone changes
    Retrofit.Builder.callbackExecutor(someBackgroundExecutor)
then the app could crash without pattern due to WeakReference expiration.