### PR TITLE
Fix error message regarding missing error View

### DIFF
--- a/mvp/src/main/java/com/hannesdorfmann/mosby/mvp/lce/MvpLceActivity.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby/mvp/lce/MvpLceActivity.java
@@ -74,7 +74,7 @@ public abstract class MvpLceActivity<CV extends View, M, V extends MvpLceView<M>
     if (errorView == null) {
       throw new NullPointerException(
           "Error view is null! Have you specified a content view in your layout xml file?"
-              + " You have to give your error View the id R.id.contentView");
+              + " You have to give your error View the id R.id.errorView");
     }
 
     errorView.setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
There was a small copy-paste mistake in an error message:

> You have to give your error View the id R.id.contentView