### PR TITLE
MviActivity may crash when restarting.

### DIFF
--- a/mvi/src/main/java/com/hannesdorfmann/mosby3/ActivityMviDelegateImpl.java
+++ b/mvi/src/main/java/com/hannesdorfmann/mosby3/ActivityMviDelegateImpl.java
@@ -196,13 +196,13 @@ public class ActivityMviDelegateImpl<V extends MvpView, P extends MviPresenter<V
     }
 
     presenterManager.cleanUp();
+  }
+
+  @Override public void onDestroy() {
     presenterManager = null;
     presenter = null;
     activity = null;
     delegateCallback = null;
-  }
-
-  @Override public void onDestroy() {
   }
 
   @Override public void onPostCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
`ActivityMviDelegateImpl` released references at `onStop()`.
It may cause NullPointerException at `onStart()` after once stopped.

https://github.com/sockeqwe/mosby/blob/master/mvi/src/main/java/com/hannesdorfmann/mosby3/ActivityMviDelegateImpl.java#L109

Does it should move to `onDestroy()`? It is respect to `FragmentMviDelegateImpl`.