### PR TITLE
Fixed ClassNotFoundException during MosbySavedState restoration by properly passing the ClassLoader

### DIFF
--- a/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/MosbySavedState.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/MosbySavedState.java
@@ -17,7 +17,9 @@ package com.hannesdorfmann.mosby3.mvp.delegate;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.view.View;
+import android.support.v4.os.ParcelableCompat;
+import android.support.v4.os.ParcelableCompatCreatorCallbacks;
+import android.support.v4.view.AbsSavedState;
 
 /**
  * The SavedState implementation to store the view's internal id to
@@ -25,18 +27,21 @@ import android.view.View;
  * @author Hannes Dorfmann
  * @since 3.0
  */
-public class MosbySavedState extends View.BaseSavedState {
+public class MosbySavedState extends AbsSavedState {
 
   public static final Parcelable.Creator<MosbySavedState> CREATOR =
-      new Parcelable.Creator<MosbySavedState>() {
-        public MosbySavedState createFromParcel(Parcel in) {
-          return new MosbySavedState(in);
+      ParcelableCompat.newCreator(new ParcelableCompatCreatorCallbacks<MosbySavedState>() {
+        public MosbySavedState createFromParcel(Parcel in, ClassLoader loader) {
+          if (loader == null) {
+            loader = MosbySavedState.class.getClassLoader();
+          }
+          return new MosbySavedState(in, loader);
         }
 
         public MosbySavedState[] newArray(int size) {
           return new MosbySavedState[size];
         }
-      };
+      });
 
   private int mosbyViewId = 0;
 
@@ -44,8 +49,8 @@ public class MosbySavedState extends View.BaseSavedState {
     super(superState);
   }
 
-  protected MosbySavedState(Parcel in) {
-    super(in);
+  protected MosbySavedState(Parcel in, ClassLoader loader) {
+    super(in, loader);
     this.mosbyViewId = in.readInt();
   }
 

--- a/presentermanager/src/main/java/com/hannesdorfmann/mosby3/MosbySavedState.java
+++ b/presentermanager/src/main/java/com/hannesdorfmann/mosby3/MosbySavedState.java
@@ -18,7 +18,9 @@ package com.hannesdorfmann.mosby3;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.view.View;
+import android.support.v4.os.ParcelableCompat;
+import android.support.v4.os.ParcelableCompatCreatorCallbacks;
+import android.support.v4.view.AbsSavedState;
 
 /**
  * The SavedState implementation to store the view's internal id to
@@ -26,18 +28,21 @@ import android.view.View;
  * @author Hannes Dorfmann
  * @since 3.0
  */
-public class MosbySavedState extends View.BaseSavedState {
+public class MosbySavedState extends AbsSavedState {
 
   public static final Creator<MosbySavedState> CREATOR =
-      new Creator<MosbySavedState>() {
-        public MosbySavedState createFromParcel(Parcel in) {
-          return new MosbySavedState(in);
+      ParcelableCompat.newCreator(new ParcelableCompatCreatorCallbacks<MosbySavedState>() {
+        public MosbySavedState createFromParcel(Parcel in, ClassLoader loader) {
+          if (loader == null) {
+            loader = MosbySavedState.class.getClassLoader();
+          }
+          return new MosbySavedState(in, loader);
         }
 
         public MosbySavedState[] newArray(int size) {
           return new MosbySavedState[size];
         }
-      };
+      });
 
   private String mosbyViewId;
 
@@ -46,8 +51,8 @@ public class MosbySavedState extends View.BaseSavedState {
     this.mosbyViewId = mosbyViewId;
   }
 
-  protected MosbySavedState(Parcel in) {
-    super(in);
+  protected MosbySavedState(Parcel in, ClassLoader loader) {
+    super(in, loader);
     this.mosbyViewId = in.readString();
   }
 

--- a/viewstate/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/MosbyViewStateSavedState.java
+++ b/viewstate/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/MosbyViewStateSavedState.java
@@ -17,6 +17,9 @@ package com.hannesdorfmann.mosby3.mvp.delegate;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.v4.os.ParcelableCompat;
+import android.support.v4.os.ParcelableCompatCreatorCallbacks;
+
 import com.hannesdorfmann.mosby3.mvp.viewstate.RestorableParcelableViewState;
 
 /**
@@ -28,15 +31,18 @@ import com.hannesdorfmann.mosby3.mvp.viewstate.RestorableParcelableViewState;
 public class MosbyViewStateSavedState extends MosbySavedState {
 
   public static final Parcelable.Creator<MosbyViewStateSavedState> CREATOR =
-      new Parcelable.Creator<MosbyViewStateSavedState>() {
-        public MosbyViewStateSavedState createFromParcel(Parcel in) {
-          return new MosbyViewStateSavedState(in);
+      ParcelableCompat.newCreator(new ParcelableCompatCreatorCallbacks<MosbyViewStateSavedState>() {
+        public MosbyViewStateSavedState createFromParcel(Parcel in, ClassLoader loader) {
+          if (loader == null) {
+            loader = RestorableParcelableViewState.class.getClassLoader();
+          }
+          return new MosbyViewStateSavedState(in, loader);
         }
 
         public MosbyViewStateSavedState[] newArray(int size) {
           return new MosbyViewStateSavedState[size];
         }
-      };
+      });
 
   private RestorableParcelableViewState mosbyViewState;
 
@@ -44,9 +50,9 @@ public class MosbyViewStateSavedState extends MosbySavedState {
     super(superState);
   }
 
-  protected MosbyViewStateSavedState(Parcel in) {
-    super(in);
-    this.mosbyViewState = in.readParcelable(RestorableParcelableViewState.class.getClassLoader());
+  protected MosbyViewStateSavedState(Parcel in, ClassLoader loader) {
+    super(in, loader);
+    this.mosbyViewState = in.readParcelable(loader);
   }
 
   @Override public void writeToParcel(Parcel out, int flags) {


### PR DESCRIPTION
This fixes the [crash described here](https://code.google.com/p/android/issues/detail?id=232471).

This is not a bug in the framework or the support library. A `ClassLoader` must always be passed to any `Parcelable` that uses `Parcel.readParcelable()` if the class to read is not a framework class. This includes the superState passed to `AbsSavedState` or `BaseSavedState` through `super()`.

1) Using `ParcelableCompat.newCreator()` we are able to get a `ClassLoader` from the system. This is a thin wrapper around the native [`Parcelable.ClassLoaderCreator`](https://developer.android.com/reference/android/os/Parcelable.ClassLoaderCreator.html). We still check if it's `null` and provide a default one to be on the safe side, but it should never be `null` in API 13+ if the `Parcelable` is created from a properly initialized `Bundle`.
2) Using `android.support.v4.view.AbsSavedState` instead of `View.BaseSavedState` we are able to pass this `ClassLoader` to `super()` so it's used to create the superState.