### PR TITLE
Replace android-apt with annotationProcessor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:2.3.1'
-    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.7'
     //  classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.5.2'
     classpath 'me.tatarka:gradle-retrolambda:3.5.0'
   }

--- a/sample-mail/build.gradle
+++ b/sample-mail/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.neenbedankt.android-apt'
 apply from: '../findbugs.gradle'
 
 
@@ -56,23 +55,23 @@ dependencies {
   compile 'io.reactivex:rxjava:' + rootProject.ext.rxjavaVersion
   compile 'io.reactivex:rxandroid:' + rootProject.ext.rxandroidVersion
 
-  apt 'com.hannesdorfmann.annotatedadapter:processor:' + rootProject.ext.annotatedadapterVersion
+  annotationProcessor 'com.hannesdorfmann.annotatedadapter:processor:' + rootProject.ext.annotatedadapterVersion
   compile 'com.hannesdorfmann.annotatedadapter:annotation:' + rootProject.ext.annotatedadapterVersion
   compile 'com.hannesdorfmann.annotatedadapter:support-recyclerview:' + rootProject.ext.annotatedadapterVersion
 
 
   compile 'com.hannesdorfmann.parcelableplease:annotation:' + rootProject.ext.parcelablepleaseVersion
-  apt 'com.hannesdorfmann.parcelableplease:processor:' + rootProject.ext.parcelablepleaseVersion
+  annotationProcessor 'com.hannesdorfmann.parcelableplease:processor:' + rootProject.ext.parcelablepleaseVersion
 
   compile 'com.jakewharton:butterknife:' + rootProject.ext.butterknifeVersion
-  apt 'com.jakewharton:butterknife-compiler:' + rootProject.ext.butterknifeVersion
+  annotationProcessor 'com.jakewharton:butterknife-compiler:' + rootProject.ext.butterknifeVersion
 
   compile 'frankiesardo:icepick:' + rootProject.ext.icepickVersion
-  apt 'frankiesardo:icepick-processor:' + rootProject.ext.icepickVersion
+  annotationProcessor 'frankiesardo:icepick-processor:' + rootProject.ext.icepickVersion
   compile 'com.hannesdorfmann.fragmentargs:annotation:' + rootProject.ext.fragmentargsVersion
-  apt 'com.hannesdorfmann.fragmentargs:processor:' + rootProject.ext.fragmentargsVersion
+  annotationProcessor 'com.hannesdorfmann.fragmentargs:processor:' + rootProject.ext.fragmentargsVersion
   compile 'com.google.dagger:dagger:' + rootProject.ext.dagger2Version
-  apt 'com.google.dagger:dagger-compiler:' + rootProject.ext.dagger2Version
+  annotationProcessor 'com.google.dagger:dagger-compiler:' + rootProject.ext.dagger2Version
   compile 'javax.annotation:javax.annotation-api:1.2'
 
 

--- a/sample-mvi/build.gradle
+++ b/sample-mvi/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'me.tatarka.retrolambda'
 apply from: '../findbugs.gradle'
 
@@ -82,7 +81,7 @@ dependencies {
   compile "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
 
   compile 'com.jakewharton:butterknife:'+rootProject.ext.butterknifeVersion
-  apt 'com.jakewharton:butterknife-compiler:' + rootProject.ext.butterknifeVersion
+  annotationProcessor 'com.jakewharton:butterknife-compiler:' + rootProject.ext.butterknifeVersion
 
   compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
   compile 'com.github.bumptech.glide:glide:3.7.0'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.neenbedankt.android-apt'
 apply from: '../findbugs.gradle'
 
 android {
@@ -36,14 +35,14 @@ dependencies {
 
 
   compile 'com.jakewharton:butterknife:'+rootProject.ext.butterknifeVersion
-  apt 'com.jakewharton:butterknife-compiler:' + rootProject.ext.butterknifeVersion
+  annotationProcessor 'com.jakewharton:butterknife-compiler:' + rootProject.ext.butterknifeVersion
 
-  apt 'com.hannesdorfmann.annotatedadapter:processor:' + rootProject.ext.annotatedadapterVersion
+  annotationProcessor 'com.hannesdorfmann.annotatedadapter:processor:' + rootProject.ext.annotatedadapterVersion
   compile 'com.hannesdorfmann.annotatedadapter:annotation:' + rootProject.ext.annotatedadapterVersion
   compile 'com.hannesdorfmann.annotatedadapter:support-recyclerview:' + rootProject.ext.annotatedadapterVersion
 
   compile 'com.hannesdorfmann.parcelableplease:annotation:' + rootProject.ext.parcelablepleaseVersion
-  apt 'com.hannesdorfmann.parcelableplease:processor:' + rootProject.ext.parcelablepleaseVersion
+  annotationProcessor 'com.hannesdorfmann.parcelableplease:processor:' + rootProject.ext.parcelablepleaseVersion
 
 
   compile 'com.squareup.leakcanary:leakcanary-android:'+ rootProject.ext.leakcanaryVersion


### PR DESCRIPTION
Annotation processing is now natively supported by Gradle, a third party plugin is no longer needed.