### PR TITLE
Use isFinishing instead of isChangingConfigurations

### DIFF
--- a/mvi/src/main/java/com/hannesdorfmann/mosby3/ActivityMviDelegateImpl.java
+++ b/mvi/src/main/java/com/hannesdorfmann/mosby3/ActivityMviDelegateImpl.java
@@ -189,8 +189,7 @@ public class ActivityMviDelegateImpl<V extends MvpView, P extends MviPresenter<V
    * @param keepPresenterInstance true, if the delegate has enabled keep
    */
   static boolean retainPresenterInstance(boolean keepPresenterInstance, Activity activity) {
-    return keepPresenterInstance && (activity.isChangingConfigurations()
-        || !activity.isFinishing());
+    return keepPresenterInstance && !activity.isFinishing();
   }
 
   @Override public void onStop() {

--- a/presentermanager/src/main/java/com/hannesdorfmann/mosby3/PresenterManager.java
+++ b/presentermanager/src/main/java/com/hannesdorfmann/mosby3/PresenterManager.java
@@ -75,7 +75,7 @@ final public class PresenterManager {
         }
 
         @Override public void onActivityDestroyed(Activity activity) {
-          if (!activity.isChangingConfigurations()) {
+          if (activity.isFinishing()) {
             // Activity will be destroyed permanently, so reset the cache
             String activityId = activityIdMap.get(activity);
             if (activityId != null) {

--- a/presentermanager/src/test/java/com/hannesdorfmann/mosby3/PresenterManagerTest.java
+++ b/presentermanager/src/test/java/com/hannesdorfmann/mosby3/PresenterManagerTest.java
@@ -154,7 +154,7 @@ public class PresenterManagerTest {
     Activity activity = Mockito.mock(Activity.class);
     Application application = Mockito.mock(Application.class);
     Mockito.when(activity.getApplication()).thenReturn(application);
-    Mockito.when(activity.isChangingConfigurations()).thenReturn(false);
+    Mockito.when(activity.isFinishing()).thenReturn(true);
 
     // This one also registers for
     ActivityScopedCache scopedCache = PresenterManager.getOrCreateActivityScopedCache(activity);
@@ -177,8 +177,8 @@ public class PresenterManagerTest {
 
     Mockito.when(portraitActivity1.getApplication()).thenReturn(application);
     Mockito.when(landscapeActivity1.getApplication()).thenReturn(application);
-    Mockito.when(portraitActivity1.isChangingConfigurations()).thenReturn(true);
-    Mockito.when(landscapeActivity1.isChangingConfigurations()).thenReturn(false);
+    Mockito.when(portraitActivity1.isFinishing()).thenReturn(false);
+    Mockito.when(landscapeActivity1.isFinishing()).thenReturn(true);
 
     // This one also registers for lifecycle events
     ActivityScopedCache scopedCache1 =
@@ -250,10 +250,10 @@ public class PresenterManagerTest {
     Mockito.when(landscapeActivity1.getApplication()).thenReturn(application);
     Mockito.when(portraitActivity2.getApplication()).thenReturn(application);
     Mockito.when(landscapeActivity2.getApplication()).thenReturn(application);
-    Mockito.when(portraitActivity1.isChangingConfigurations()).thenReturn(true);
-    Mockito.when(landscapeActivity1.isChangingConfigurations()).thenReturn(false);
-    Mockito.when(portraitActivity2.isChangingConfigurations()).thenReturn(true);
-    Mockito.when(landscapeActivity2.isChangingConfigurations()).thenReturn(false);
+    Mockito.when(portraitActivity1.isFinishing()).thenReturn(false);
+    Mockito.when(landscapeActivity1.isFinishing()).thenReturn(true);
+    Mockito.when(portraitActivity2.isFinishing()).thenReturn(false);
+    Mockito.when(landscapeActivity2.isFinishing()).thenReturn(true);
 
     // This one also registers for lifecycle events
     ActivityScopedCache activity1ScopedCache1 =


### PR DESCRIPTION
When the activity is destroyed by the system (e.g. testing with "Don't keep activities" enabled) `presenter.destroy()` is not being called because `isFinishing` is false.  However `PresenterManager` just checks `isChangingConfigurations()` so the cache is reset and the presenter is not retrieved when the activity is recreated.  So a new presenter is created and now we have two presenter instances.

This changes the logic to only rely on `isFinishing` to destroy the presenter and reset the cache.