### PR TITLE
Support android x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ android:
   components:
   - tools
   - platform-tools
-  - build-tools-27.0.1
+  - build-tools-27.0.3
   - extra-android-m2repository
   - android-27
   - sys-img-armeabi-v7a-android-17
@@ -22,7 +22,7 @@ jdk:
 - oraclejdk8
 licenses:
 - android-sdk-license-.+
-- android-sdk-license-c81a61d9
+- android-sdk-license-2742d1c5
 env:
   global:
   - MALLOC_ARENA_MAX=2

--- a/utils-fragment/src/main/java/android/support/v4/app/BackstackAccessor.java
+++ b/utils-fragment/src/main/java/android/support/v4/app/BackstackAccessor.java
@@ -17,6 +17,9 @@
 
 package android.support.v4.app;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 /**
  * With this utility class one can access the fragment backstack
  *
@@ -37,8 +40,24 @@ public class BackstackAccessor {
    * stack)
    */
   public static boolean isFragmentOnBackStack(Fragment fragment) {
-    return fragment.isInBackStack();
+      try {
+          return fragment.isInBackStack();
+      } catch (IllegalAccessError e) {
+          return isInBackStackAndroidX(fragment);
+      }
   }
+
+    /**
+     * As of version 1.0 of AndroidX - fragment.isInBackStack() is package private which leads to
+     * an IllegalAccessError being thrown when trying to use it.
+     * This method is a temporary workaround until the issue is resolved in AndroidX.
+     */
+    private static boolean isInBackStackAndroidX(final Fragment fragment) {
+        final StringWriter writer = new StringWriter();
+        fragment.dump("", null, new PrintWriter(writer), null);
+        final String dump = writer.toString();
+        return !dump.contains("mBackStackNesting=0");
+    }
 /*
   public static boolean isFragmentOnBackStack(Fragment fragment) {
 


### PR DESCRIPTION
As of version 1.0 of AndroidX, fragment.isInBackStack() is package private
and attempting to use is leads to an IllegalAccessError exception.

This pr introduces a temporary workaround for this issue by
determining if the fragment is in the backstack from the information
returned by fragment.dump().