### PR TITLE
fix crash of mvi-sample 

### DIFF
--- a/sample-mvi/src/main/java/com/hannesdorfmann/mosby3/sample/mvi/view/shoppingcartoverview/ShoppingCartOverviewPresenter.java
+++ b/sample-mvi/src/main/java/com/hannesdorfmann/mosby3/sample/mvi/view/shoppingcartoverview/ShoppingCartOverviewPresenter.java
@@ -57,7 +57,9 @@ public class ShoppingCartOverviewPresenter
         intent(ShoppingCartOverviewView::selectItemsIntent)
             .mergeWith(clearSelectionIntent.map(ignore -> Collections.emptyList()))
             .doOnNext(items -> Timber.d("intent: selected items %d", items.size()))
-            .startWith(new ArrayList<Product>(0));
+            .startWith(new ArrayList<Product>(0))
+            .publish()
+            .refCount();
 
     //
     // Delete multiple selected Items


### PR DESCRIPTION
`MviBasePresenter.intent` replace ReplaySubject with UnicastSubject.
selectedItemsIntent used from multi subscribers, So mvi-sample project crashed now.

I used Connectable Observable(publish + refcount), it resolved.
