### PR TITLE
Use Fragment onAttach(Context) over deprecated onAttach(Activity)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ android:
   components:
   - tools
   - platform-tools
-  - build-tools-27.0.3
+  - build-tools-28.0.1
   - extra-android-m2repository
-  - android-27
+  - android-28
   - sys-img-armeabi-v7a-android-17
 before_install:
 - echo "org.gradle.parallel=false" >> ~/.gradle/gradle.properties
-- yes | sdkmanager "platforms;android-27"
+- yes | sdkmanager "platforms;android-28"
 before_script:
 jdk:
 - oraclejdk8

--- a/mvi-integration-test/build.gradle
+++ b/mvi-integration-test/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     androidTestCompile 'com.android.support.test:rules:' + rootProject.ext.androidSupportTestVersion
     androidTestCompile 'junit:junit:' + rootProject.ext.junitVersion
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    compile 'com.android.support:design:25.3.1'
+    compile 'com.android.support:design:' + rootProject.ext.supportLibVersion
 }
 
 configurations.all {

--- a/mvi/src/main/java/com/hannesdorfmann/mosby3/mvi/MviFragment.java
+++ b/mvi/src/main/java/com/hannesdorfmann/mosby3/mvi/MviFragment.java
@@ -111,12 +111,12 @@ public abstract class MviFragment<V extends MvpView, P extends MviPresenter<V, ?
     getMvpDelegate().onActivityCreated(savedInstanceState);
   }
 
-  @CallSuper @Override public void onAttach(Activity activity) {
+  @CallSuper @Deprecated @Override public void onAttach(Activity activity) {
     super.onAttach(activity);
     getMvpDelegate().onAttach(activity);
   }
 
-  @Override public void onAttach(Context context) {
+  @CallSuper @Override public void onAttach(Context context) {
     super.onAttach(context);
     getMvpDelegate().onAttach(context);
   }

--- a/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/MvpDialogFragment.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/MvpDialogFragment.java
@@ -2,6 +2,7 @@ package com.hannesdorfmann.mosby3.mvp;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -125,6 +126,11 @@ public abstract class MvpDialogFragment<V extends MvpView, P extends MvpPresente
   @Override public void onAttach(Activity activity) {
     super.onAttach(activity);
     getMvpDelegate().onAttach(activity);
+  }
+
+  @Override public void onAttach(Context context) {
+    super.onAttach(context);
+    getMvpDelegate().onAttach(context);
   }
 
   @Override public void onDetach() {

--- a/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/MvpFragment.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/MvpFragment.java
@@ -17,13 +17,15 @@
 package com.hannesdorfmann.mosby3.mvp;
 
 import android.app.Activity;
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.view.View;
-import com.hannesdorfmann.mosby3.mvp.delegate.FragmentMvpDelegateImpl;
+
 import com.hannesdorfmann.mosby3.mvp.delegate.FragmentMvpDelegate;
+import com.hannesdorfmann.mosby3.mvp.delegate.FragmentMvpDelegateImpl;
 import com.hannesdorfmann.mosby3.mvp.delegate.MvpDelegateCallback;
 
 /**
@@ -128,9 +130,14 @@ public abstract class MvpFragment<V extends MvpView, P extends MvpPresenter<V>> 
     getMvpDelegate().onActivityCreated(savedInstanceState);
   }
 
-  @Override public void onAttach(Activity activity) {
+  @Deprecated @Override public void onAttach(Activity activity) {
     super.onAttach(activity);
     getMvpDelegate().onAttach(activity);
+  }
+
+  @Override public void onAttach(Context context) {
+    super.onAttach(context);
+    getMvpDelegate().onAttach(context);
   }
 
   @Override public void onDetach() {

--- a/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/FragmentMvpDelegate.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/FragmentMvpDelegate.java
@@ -17,6 +17,7 @@
 package com.hannesdorfmann.mosby3.mvp.delegate;
 
 import android.app.Activity;
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -40,6 +41,7 @@ import com.hannesdorfmann.mosby3.mvp.MvpView;
  * <li>{@link #onActivityCreated(Bundle)} </li>
  * <li>{@link #onSaveInstanceState(Bundle)} </li>
  * <li>{@link #onAttach(Activity)} </li>
+ * <li>{@link #onAttach(Context)} </li>
  * <li>{@link #onDetach()}</li>
  * <li></li>
  * </ul>
@@ -109,7 +111,15 @@ public interface FragmentMvpDelegate<V extends MvpView, P extends MvpPresenter<V
    *
    * @param activity The activity the fragment is attached to
    */
+  @Deprecated
   void onAttach(Activity activity);
+
+  /**
+   * Must be called from {@link Fragment#onAttach(Context)}
+   *
+   * @param context The context the fragment is attached to
+   */
+  void onAttach(Context context);
 
   /**
    * Must be called from {@link Fragment#onDetach()}

--- a/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/FragmentMvpDelegateImpl.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/FragmentMvpDelegateImpl.java
@@ -17,6 +17,7 @@
 package com.hannesdorfmann.mosby3.mvp.delegate;
 
 import android.app.Activity;
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -207,6 +208,10 @@ public class FragmentMvpDelegateImpl<V extends MvpView, P extends MvpPresenter<V
   }
 
   @Override public void onAttach(Activity activity) {
+
+  }
+
+  @Override public void onAttach(Context context) {
 
   }
 

--- a/mvp/src/test/java/com/hannesdorfmann/mosby3/mvp/delegate/FragmentMvpDelegateImplTest.java
+++ b/mvp/src/test/java/com/hannesdorfmann/mosby3/mvp/delegate/FragmentMvpDelegateImplTest.java
@@ -18,6 +18,7 @@
 package com.hannesdorfmann.mosby3.mvp.delegate;
 
 import android.app.Application;
+import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
@@ -142,7 +143,7 @@ public class FragmentMvpDelegateImplTest {
 
   private void startFragment(FragmentMvpDelegateImpl<MvpView, MvpPresenter<MvpView>> delegate,
       Bundle bundle) {
-    delegate.onAttach(activity);
+    delegate.onAttach((Context) activity);
     delegate.onCreate(bundle);
     delegate.onViewCreated(null, bundle);
     delegate.onActivityCreated(bundle);

--- a/viewstate/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/FragmentMvpViewStateDelegateImpl.java
+++ b/viewstate/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/FragmentMvpViewStateDelegateImpl.java
@@ -17,6 +17,7 @@
 package com.hannesdorfmann.mosby3.mvp.delegate;
 
 import android.app.Activity;
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
@@ -264,6 +265,9 @@ public class FragmentMvpViewStateDelegateImpl<V extends MvpView, P extends MvpPr
   }
 
   @Override public void onAttach(Activity activity) {
+  }
+
+  @Override public void onAttach(Context context) {
   }
 
   @Override public void onDetach() {


### PR DESCRIPTION
Expose the Fragment onAttach(Context) method, which is preferred over the deprecated onAttach(Activity).

Also use `ext.supportLibVersion` in the design dependency of the mvi-integration-test build script