### PR TITLE
View without Activity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ android:
   components:
   - tools
   - platform-tools
-  - build-tools-27.0.3
+  - build-tools-28.0.1
   - extra-android-m2repository
-  - android-27
+  - android-28
   - sys-img-armeabi-v7a-android-17
 before_install:
 - echo "org.gradle.parallel=false" >> ~/.gradle/gradle.properties
-- yes | sdkmanager "platforms;android-27"
+- yes | sdkmanager "platforms;android-28"
 before_script:
 jdk:
 - oraclejdk8

--- a/mvi-integration-test/build.gradle
+++ b/mvi-integration-test/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     androidTestCompile 'com.android.support.test:rules:' + rootProject.ext.androidSupportTestVersion
     androidTestCompile 'junit:junit:' + rootProject.ext.junitVersion
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    compile 'com.android.support:design:25.3.1'
+    compile 'com.android.support:design:' + rootProject.ext.supportLibVersion
 }
 
 configurations.all {

--- a/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/ViewGroupDelegateCallback.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/ViewGroupDelegateCallback.java
@@ -52,8 +52,10 @@ public interface ViewGroupDelegateCallback<V extends MvpView, P extends MvpPrese
   Context getContext();
 
   /**
-   * A android.view.View can added (in)directly to a Activity or a WindowManager,
-   * in which case only destroy Presenter is needed, not release
+   * A android.view.View can be added (in)directly to a Activity or a WindowManager,
+   * in which case only destroying the Presenter is needed, not detaching
+   *
+   * @return true when your view will be used within an Activity, otherwise false when used within a WindowManager
    */
   boolean isViewOnActivity();
 }

--- a/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/ViewGroupDelegateCallback.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/ViewGroupDelegateCallback.java
@@ -50,4 +50,10 @@ public interface ViewGroupDelegateCallback<V extends MvpView, P extends MvpPrese
    * @since 3.0
    */
   Context getContext();
+
+  /**
+   * A android.view.View can added (in)directly to a Activity or a WindowManager,
+   * in which case only destroy Presenter is needed, not release
+   */
+  boolean isViewOnActivity();
 }

--- a/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/layout/MvpFrameLayout.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/layout/MvpFrameLayout.java
@@ -125,4 +125,9 @@ public abstract class MvpFrameLayout<V extends MvpView, P extends MvpPresenter<V
   @Override public final void superOnRestoreInstanceState(Parcelable state) {
     super.onRestoreInstanceState(state);
   }
+
+  @Override
+  public boolean isViewOnActivity() {
+    return true;
+  }
 }

--- a/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/layout/MvpLinearLayout.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/layout/MvpLinearLayout.java
@@ -126,4 +126,9 @@ public abstract class MvpLinearLayout<V extends MvpView, P extends MvpPresenter<
   @Override public final void superOnRestoreInstanceState(Parcelable state) {
     super.onRestoreInstanceState(state);
   }
+
+  @Override
+  public boolean isViewOnActivity() {
+    return true;
+  }
 }

--- a/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/layout/MvpRelativeLayout.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/layout/MvpRelativeLayout.java
@@ -125,4 +125,9 @@ public abstract class MvpRelativeLayout<V extends MvpView, P extends MvpPresente
   @Override public final void superOnRestoreInstanceState(Parcelable state) {
     super.onRestoreInstanceState(state);
   }
+
+  @Override
+  public boolean isViewOnActivity() {
+    return true;
+  }
 }

--- a/mvp/src/test/java/com/hannesdorfmann/mosby3/mvp/delegate/PartialViewGroupMvpDelegateCallbackImpl.java
+++ b/mvp/src/test/java/com/hannesdorfmann/mosby3/mvp/delegate/PartialViewGroupMvpDelegateCallbackImpl.java
@@ -42,4 +42,9 @@ public abstract class PartialViewGroupMvpDelegateCallbackImpl
   @Override public Parcelable superOnSaveInstanceState() {
     return Mockito.mock(AbsSavedState.class);
   }
+
+  @Override
+  public boolean isViewOnActivity() {
+    return true;
+  }
 }

--- a/mvp/src/test/java/com/hannesdorfmann/mosby3/mvp/delegate/ViewGroupMvpDelegateImplTest.java
+++ b/mvp/src/test/java/com/hannesdorfmann/mosby3/mvp/delegate/ViewGroupMvpDelegateImplTest.java
@@ -21,10 +21,11 @@ import android.app.Application;
 import android.os.Parcelable;
 import android.support.v4.app.FragmentActivity;
 import android.view.View;
+
 import com.hannesdorfmann.mosby3.mvp.MvpPresenter;
 import com.hannesdorfmann.mosby3.mvp.MvpView;
+
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -53,6 +54,7 @@ public class ViewGroupMvpDelegateImplTest {
     Mockito.doCallRealMethod().when(callback).setPresenter(presenter);
     Mockito.doCallRealMethod().when(callback).getPresenter();
     Mockito.doCallRealMethod().when(callback).superOnSaveInstanceState();
+    Mockito.doCallRealMethod().when(callback).isViewOnActivity();
 
     activity = Mockito.mock(FragmentActivity.class);
     application = Mockito.mock(Application.class);
@@ -105,6 +107,7 @@ public class ViewGroupMvpDelegateImplTest {
     PartialViewGroupMvpDelegateCallbackImpl callback1 =
         Mockito.mock(PartialViewGroupMvpDelegateCallbackImpl.class);
     Mockito.doCallRealMethod().when(callback1).setPresenter(presenter1);
+    Mockito.doCallRealMethod().when(callback1).isViewOnActivity();
     Mockito.doCallRealMethod().when(callback1).getPresenter();
     View androidView1 = Mockito.mock(View.class);
 

--- a/mvp/src/test/java/com/hannesdorfmann/mosby3/mvp/delegate/ViewGroupMvpDelegateOnWindowImplTest.java
+++ b/mvp/src/test/java/com/hannesdorfmann/mosby3/mvp/delegate/ViewGroupMvpDelegateOnWindowImplTest.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright 2015 Hannes Dorfmann.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hannesdorfmann.mosby3.mvp.delegate;
+
+import android.app.Application;
+import android.view.View;
+
+import com.hannesdorfmann.mosby3.mvp.MvpPresenter;
+import com.hannesdorfmann.mosby3.mvp.MvpView;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ViewGroupMvpDelegateOnWindowImplTest {
+
+  private MvpView view;
+  private MvpPresenter<MvpView> presenter;
+  private PartialViewGroupMvpDelegateCallbackImpl callback;
+  private ViewGroupMvpDelegateImpl<MvpView, MvpPresenter<MvpView>> delegate;
+  private Application application;
+  private View androidView;
+
+  @Before public void initComponents() {
+    view = new MvpView() {
+    };
+
+    presenter = Mockito.mock(MvpPresenter.class);
+    callback = Mockito.mock(PartialViewGroupMvpDelegateCallbackImpl.class);
+    Mockito.doCallRealMethod().when(callback).setPresenter(presenter);
+    Mockito.doCallRealMethod().when(callback).getPresenter();
+    Mockito.doCallRealMethod().when(callback).superOnSaveInstanceState();
+    Mockito.when(callback.isViewOnActivity()).thenReturn(false);
+
+    application = Mockito.mock(Application.class);
+    androidView = Mockito.mock(View.class);
+
+    Mockito.when(callback.getMvpView()).thenReturn(view);
+    Mockito.when(callback.getContext()).thenReturn(application);
+    Mockito.when(androidView.isInEditMode()).thenReturn(false);
+
+    delegate = new ViewGroupMvpDelegateImpl<>(androidView, callback, true);
+  }
+
+  @Test public void appStartWithDoesNotSavePresenter() {
+    startViewGroup(1, 1, 1);
+    finishViewGroup(1);
+    delegate = new ViewGroupMvpDelegateImpl<>(androidView, callback, true);
+    startViewGroup(2, 2, 2);
+    finishViewGroup(2);
+  }
+
+  @Test public void appStartFinishing() {
+    startViewGroup(1, 1, 1);
+    finishViewGroup(1);
+  }
+
+  @Test public void dontKeepPresenter() {
+    delegate =
+        new ViewGroupMvpDelegateImpl<MvpView, MvpPresenter<MvpView>>(androidView, callback, false);
+    startViewGroup(1, 1, 1);
+    finishViewGroup(1);
+    delegate =
+        new ViewGroupMvpDelegateImpl<MvpView, MvpPresenter<MvpView>>(androidView, callback, false);
+    startViewGroup(2, 2, 2);
+    finishViewGroup(2);
+  }
+
+  private void startViewGroup(int createPresenter, int setPresenter, int attachView) {
+    Mockito.when(callback.createPresenter()).thenReturn(presenter);
+    delegate.onAttachedToWindow();
+
+    Mockito.verify(callback, Mockito.times(createPresenter)).createPresenter();
+    Mockito.verify(callback, Mockito.times(setPresenter)).setPresenter(presenter);
+    Mockito.verify(presenter, Mockito.times(attachView)).attachView(view);
+  }
+
+  private void finishViewGroup(int destroyCount) {
+    Mockito.when(callback.getPresenter()).thenReturn(presenter);
+
+    delegate.onDetachedFromWindow();
+    Mockito.verify(presenter, Mockito.times(destroyCount)).destroy();
+  }
+}

--- a/viewstate/src/main/java/com/hannesdorfmann/mosby3/mvp/viewstate/layout/MvpViewStateFrameLayout.java
+++ b/viewstate/src/main/java/com/hannesdorfmann/mosby3/mvp/viewstate/layout/MvpViewStateFrameLayout.java
@@ -85,4 +85,9 @@ public abstract class MvpViewStateFrameLayout<V extends MvpView, P extends MvpPr
     // can be overridden in subclass
   }
 
+  @Override
+  public boolean isViewOnActivity() {
+    return true;
+  }
+
 }

--- a/viewstate/src/main/java/com/hannesdorfmann/mosby3/mvp/viewstate/layout/MvpViewStateLinearLayout.java
+++ b/viewstate/src/main/java/com/hannesdorfmann/mosby3/mvp/viewstate/layout/MvpViewStateLinearLayout.java
@@ -85,4 +85,9 @@ public abstract class MvpViewStateLinearLayout<V extends MvpView, P extends MvpP
     // can be overridden in subclass
   }
 
+  @Override
+  public boolean isViewOnActivity() {
+    return true;
+  }
+
 }

--- a/viewstate/src/main/java/com/hannesdorfmann/mosby3/mvp/viewstate/layout/MvpViewStateRelativeLayout.java
+++ b/viewstate/src/main/java/com/hannesdorfmann/mosby3/mvp/viewstate/layout/MvpViewStateRelativeLayout.java
@@ -85,4 +85,9 @@ public abstract class MvpViewStateRelativeLayout<V extends MvpView, P extends Mv
     // can be overridden in subclass
   }
 
+  @Override
+  public boolean isViewOnActivity() {
+    return true;
+  }
+
 }

--- a/viewstate/src/test/java/com/hannesdorfmann/mosby3/mvp/delegate/PartialViewGroupMvpViewStateDelegateCallbackImpl.java
+++ b/viewstate/src/test/java/com/hannesdorfmann/mosby3/mvp/delegate/PartialViewGroupMvpViewStateDelegateCallbackImpl.java
@@ -49,4 +49,9 @@ public abstract class PartialViewGroupMvpViewStateDelegateCallbackImpl implement
   @Override public Parcelable superOnSaveInstanceState() {
     return Mockito.mock(AbsSavedState.class);
   }
+
+  @Override
+  public boolean isViewOnActivity() {
+    return true;
+  }
 }


### PR DESCRIPTION
Allow mosby to support view without activity:
**Reference ticket:** https://github.com/sockeqwe/mosby/issues/281

Alternatively, we can just remove the Exception when there is no activity and switch automatically to Window-mode for ViewGroup base DelegateCallback. But I guess if we add this feature we would like it to be enforced and managed.
So the user will need to implement "public boolean isViewOnActivity()"
It basically switch to a mod where it does not expect to save a state nor detach a view without destroying.


From a user perspective, a CustomView can be use alternatively by a Activity or a Window directly, an easy way to support that would be to implement:

`
public boolean isViewOnActivity() {
   return PresenterManager.getActivity(delegateCallback.getContext()) != null
}
`