### PR TITLE
Fixed detaching and destroying presenter in ViewGroup after view added to container again.

### DIFF
--- a/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/ViewGroupMvpDelegateImpl.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/delegate/ViewGroupMvpDelegateImpl.java
@@ -107,6 +107,7 @@ public class ViewGroupMvpDelegateImpl<V extends MvpView, P extends MvpPresenter<
       mosbyViewId = UUID.randomUUID().toString();
       PresenterManager.putPresenter(PresenterManager.getActivity(context), mosbyViewId, presenter);
     }
+    presenterDestroyed = false;
     return presenter;
   }
 
@@ -167,6 +168,7 @@ public class ViewGroupMvpDelegateImpl<V extends MvpView, P extends MvpPresenter<
 
     delegateCallback.setPresenter(presenter);
     presenter.attachView(view);
+    presenterDetached = false;
 
     /*
     if (viewStateWillBeRestored) {


### PR DESCRIPTION
Steps to reproduce bug:
1. Create view which is inherited from for example `MvpFrameLayout`
2. Add view to any `ViewGroup`
3. Remove from the `ViewGroup` (`detachView()` and `destroy()` methods from `MvpPresenter` will be called)
4. Add view again to `ViewGroup`
5. Remove view from `ViewGroup`
6. `detachView()` and `destroy()` methods from `MvpPresenter` not will be called