### PR TITLE
Provide faster feedback for execution by Parallel Build

### DIFF
--- a/.buildscript/deploy_snapshot.sh
+++ b/.buildscript/deploy_snapshot.sh
@@ -15,16 +15,16 @@ elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
 else
   echo "Deploying..."
   ./gradlew --stop
-  echo "org.gradle.parallel=false" >> ~/.gradle/gradle.properties
+  echo "org.gradle.parallel=true" >> ~/.gradle/gradle.properties
   echo "org.gradle.configureondemand=false" >> ~/.gradle/gradle.properties
   openssl aes-256-cbc -K $encrypted_8739fbca6d38_key -iv $encrypted_8739fbca6d38_iv -in .buildscript/key.gpg.enc -out key.gpg -d
   gpg --import key.gpg
   echo "signing.keyId=E508C045" >> gradle.properties
   echo "signing.password=$PGP_KEY" >> gradle.properties
   echo "signing.secretKeyRingFile=/home/travis/.gnupg/secring.gpg" >> gradle.properties
-  echo "org.gradle.parallel=false" >> gradle.properties
+  echo "org.gradle.parallel=true" >> gradle.properties
   echo "org.gradle.configureondemand=false" >> gradle.properties
-  ./gradlew --no-daemon uploadArchives -Dorg.gradle.parallel=false -Dorg.gradle.configureondemand=false
+  ./gradlew --no-daemon uploadArchives -Dorg.gradle.parallel=true -Dorg.gradle.configureondemand=true
   rm key.gpg
   git reset --hard
   echo "Deployed!"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ android:
   - android-28
   - sys-img-armeabi-v7a-android-17
 before_install:
-- echo "org.gradle.parallel=false" >> ~/.gradle/gradle.properties
+- echo "org.gradle.parallel=true" >> ~/.gradle/gradle.properties
 - yes | sdkmanager "platforms;android-28"
 before_script:
 jdk:


### PR DESCRIPTION

[Parallel builds](https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html#sec:parallel_execution). This project contains multiple modules. Parallel builds can improve the build speed by executing tasks in parallel. We can enable this feature by setting `org.gradle.parallel=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
